### PR TITLE
Modify test event handling

### DIFF
--- a/src/nunit-gui/Presenters/MainPresenter.cs
+++ b/src/nunit-gui/Presenters/MainPresenter.cs
@@ -58,12 +58,12 @@ namespace TestCentric.Gui.Presenters
         private void WireUpEvents()
         {
             // Model Events
-            _model.TestsLoading += NotifyTestsLoading;
-            _model.TestLoaded += (ea) => InitializeMainMenu();
-            _model.TestUnloaded += (ea) => InitializeMainMenu();
-            _model.TestReloaded += (ea) => InitializeMainMenu();
-            _model.RunStarting += (ea) => InitializeMainMenu();
-            _model.RunFinished += (ea) => InitializeMainMenu();
+            _model.Events.TestsLoading += NotifyTestsLoading;
+            _model.Events.TestLoaded += (ea) => InitializeMainMenu();
+            _model.Events.TestUnloaded += (ea) => InitializeMainMenu();
+            _model.Events.TestReloaded += (ea) => InitializeMainMenu();
+            _model.Events.RunStarting += (ea) => InitializeMainMenu();
+            _model.Events.RunFinished += (ea) => InitializeMainMenu();
 
             // View Events
             _view.Load += MainForm_Load;

--- a/src/nunit-gui/Presenters/ProgressBarPresenter.cs
+++ b/src/nunit-gui/Presenters/ProgressBarPresenter.cs
@@ -43,12 +43,12 @@ namespace TestCentric.Gui.Presenters
 
         private void WireUpEvents()
         {
-            _model.TestLoaded += (ea) => { Initialize(100); };
-            _model.TestUnloaded += (ea) => { Initialize(100); };
-            _model.TestReloaded += (ea) => { Initialize(100); };
-            _model.RunStarting += (ea) => { Initialize(ea.TestCount); };
-            _model.TestFinished += (ea) => { ReportTestOutcome(ea.Result); };
-            _model.SuiteFinished += (ea) => { ReportTestOutcome(ea.Result); };
+            _model.Events.TestLoaded += (ea) => { Initialize(100); };
+            _model.Events.TestUnloaded += (ea) => { Initialize(100); };
+            _model.Events.TestReloaded += (ea) => { Initialize(100); };
+            _model.Events.RunStarting += (ea) => { Initialize(ea.TestCount); };
+            _model.Events.TestFinished += (ea) => { ReportTestOutcome(ea.Result); };
+            _model.Events.SuiteFinished += (ea) => { ReportTestOutcome(ea.Result); };
         }
 
         public void Initialize(int max)

--- a/src/nunit-gui/Presenters/StatusBarPresenter.cs
+++ b/src/nunit-gui/Presenters/StatusBarPresenter.cs
@@ -50,13 +50,13 @@ namespace TestCentric.Gui.Presenters
 
         private void WireUpEvents()
         {
-            _model.TestLoaded += OnTestLoaded;
-            _model.TestReloaded += OnTestReloaded;
-            _model.TestUnloaded += OnTestUnloaded;
-            _model.RunStarting += OnRunStarting;
-            _model.RunFinished += OnRunFinished;
-            _model.TestStarting += OnTestStarting;
-            _model.TestFinished += OnTestFinished;
+            _model.Events.TestLoaded += OnTestLoaded;
+            _model.Events.TestReloaded += OnTestReloaded;
+            _model.Events.TestUnloaded += OnTestUnloaded;
+            _model.Events.RunStarting += OnRunStarting;
+            _model.Events.RunFinished += OnRunFinished;
+            _model.Events.TestStarting += OnTestStarting;
+            _model.Events.TestFinished += OnTestFinished;
         }
 
         private void OnTestLoaded(TestNodeEventArgs ea)

--- a/src/nunit-gui/Presenters/TestPropertiesPresenter.cs
+++ b/src/nunit-gui/Presenters/TestPropertiesPresenter.cs
@@ -51,11 +51,11 @@ namespace TestCentric.Gui.Presenters
 
         private void WireUpEvents()
         {
-            _model.TestLoaded += (ea) => _view.Visible = true;
-            _model.TestReloaded += (ea) => _view.Visible = true;
-            _model.TestUnloaded += (ea) => _view.Visible = false;
-            _model.RunFinished += (ea) => DisplaySelectedItem();
-            _model.SelectedItemChanged += (ea) => OnSelectedItemChanged(ea.TestItem);
+            _model.Events.TestLoaded += (ea) => _view.Visible = true;
+            _model.Events.TestReloaded += (ea) => _view.Visible = true;
+            _model.Events.TestUnloaded += (ea) => _view.Visible = false;
+            _model.Events.RunFinished += (ea) => DisplaySelectedItem();
+            _model.Events.SelectedItemChanged += (ea) => OnSelectedItemChanged(ea.TestItem);
             _view.DisplayHiddenPropertiesChanged += () => DisplaySelectedItem();
         }
 

--- a/src/nunit-gui/Presenters/TreeViewPresenter.cs
+++ b/src/nunit-gui/Presenters/TreeViewPresenter.cs
@@ -66,29 +66,29 @@ namespace TestCentric.Gui.Presenters
         private void WireUpEvents()
         {
             // Model actions
-            _model.TestLoaded += (ea) =>
+            _model.Events.TestLoaded += (ea) =>
             {
                 _strategy.OnTestLoaded(ea.Test);
                 InitializeRunCommands();
             };
 
-            _model.TestReloaded += (ea) =>
+            _model.Events.TestReloaded += (ea) =>
             {
                 _strategy.OnTestLoaded(ea.Test);
                 InitializeRunCommands();
             };
 
-            _model.TestUnloaded += (ea) =>
+            _model.Events.TestUnloaded += (ea) =>
             {
                 _strategy.OnTestUnloaded();
                 InitializeRunCommands();
             };
 
-            _model.RunStarting += (ea) => InitializeRunCommands();
-            _model.RunFinished += (ea) => InitializeRunCommands();
+            _model.Events.RunStarting += (ea) => InitializeRunCommands();
+            _model.Events.RunFinished += (ea) => InitializeRunCommands();
 
-            _model.TestFinished += (ea) => _strategy.OnTestFinished(ea.Result);
-            _model.SuiteFinished += (ea) => _strategy.OnTestFinished(ea.Result);
+            _model.Events.TestFinished += (ea) => _strategy.OnTestFinished(ea.Result);
+            _model.Events.SuiteFinished += (ea) => _strategy.OnTestFinished(ea.Result);
 
             // View actions - Initial Load
             _view.Load += (s, e) =>

--- a/src/nunit-gui/Presenters/XmlPresenter.cs
+++ b/src/nunit-gui/Presenters/XmlPresenter.cs
@@ -51,11 +51,11 @@ namespace TestCentric.Gui.Presenters
 
         private void WireUpEvents()
         {
-            _model.TestLoaded += (ea) => _view.Visible = true;
-            _model.TestReloaded += (ea) => _view.Visible = true;
-            _model.TestUnloaded += (ea) => _view.Visible = false;
-            _model.RunFinished += (ea) => DisplayXml();
-            _model.SelectedItemChanged += (ea) => OnSelectedItemChanged(ea.TestItem);
+            _model.Events.TestLoaded += (ea) => _view.Visible = true;
+            _model.Events.TestReloaded += (ea) => _view.Visible = true;
+            _model.Events.TestUnloaded += (ea) => _view.Visible = false;
+            _model.Events.RunFinished += (ea) => DisplayXml();
+            _model.Events.SelectedItemChanged += (ea) => OnSelectedItemChanged(ea.TestItem);
 
             _view.SelectAllCommand += () =>
             {

--- a/src/nunit-gui/nunit-gui.csproj
+++ b/src/nunit-gui/nunit-gui.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{9E15166C-D2B7-4B24-AB1C-1C69FFCEC9D3}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NUnit.Gui</RootNamespace>
+    <RootNamespace>TestCentric.Gui</RootNamespace>
     <AssemblyName>nunit-gui</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/nunit.testmodel/Model/ITestEvents.cs
+++ b/src/nunit.testmodel/Model/ITestEvents.cs
@@ -1,0 +1,70 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Model
+{
+    /// <summary>
+    /// Delegates for all events related to the model
+    /// </summary>
+    public delegate void TestEventHandler(TestEventArgs args);
+    public delegate void RunStartingEventHandler(RunStartingEventArgs args);
+    public delegate void TestNodeEventHandler(TestNodeEventArgs args);
+    public delegate void TestResultEventHandler(TestResultEventArgs args);
+    public delegate void TestItemEventHandler(TestItemEventArgs args);
+    public delegate void TestOutputEventHandler(TestOutputEventArgs args);
+    public delegate void TestFilesLoadingEventHandler(TestFilesLoadingEventArgs args);
+
+    /// <summary>
+    /// ITestEvents provides events for all actions in the model, both those
+    /// caused by an engine action like a test completion and those originated
+    /// in the model itself like starting a test run.
+    /// </summary>
+    public interface ITestEvents
+    {
+        // Events related to loading and unloading tests.
+        event TestFilesLoadingEventHandler TestsLoading;
+        event TestEventHandler TestsReloading;
+        event TestEventHandler TestsUnloading;
+
+        event TestNodeEventHandler TestLoaded;
+        event TestNodeEventHandler TestReloaded;
+        event TestEventHandler TestUnloaded;
+
+        // Events related to running tests
+        event RunStartingEventHandler RunStarting;
+        event TestNodeEventHandler SuiteStarting;
+        event TestNodeEventHandler TestStarting;
+
+        event TestResultEventHandler RunFinished;
+        event TestResultEventHandler SuiteFinished;
+        event TestResultEventHandler TestFinished;
+
+        event TestOutputEventHandler TestOutput;
+
+        // Event used to broadcast a change in the selected
+        // item, so that all presenters may be notified.
+        event TestItemEventHandler SelectedItemChanged;
+
+        event TestEventHandler CategorySelectionChanged;
+    }
+}

--- a/src/nunit.testmodel/Model/ITestModel.cs
+++ b/src/nunit.testmodel/Model/ITestModel.cs
@@ -26,8 +26,15 @@ using NUnit.Engine;
 
 namespace TestCentric.Gui.Model
 {
-    public interface ITestModel : ITestEvents, IServiceLocator, System.IDisposable
+    public interface ITestModel : IServiceLocator, System.IDisposable
     {
+        #region General Properties
+
+        // Event Dispatcher
+        ITestEvents Events { get; }
+
+        #endregion
+
         #region Properties
 
         CommandLineOptions Options { get; }

--- a/src/nunit.testmodel/Model/ITestModel.cs
+++ b/src/nunit.testmodel/Model/ITestModel.cs
@@ -26,41 +26,8 @@ using NUnit.Engine;
 
 namespace TestCentric.Gui.Model
 {
-    /// <summary>
-    /// Delegates for all events related to the model
-    /// </summary>
-    public delegate void TestEventHandler(TestEventArgs args);
-    public delegate void RunStartingEventHandler(RunStartingEventArgs args);
-    public delegate void TestNodeEventHandler(TestNodeEventArgs args);
-    public delegate void TestResultEventHandler(TestResultEventArgs args);
-    public delegate void TestItemEventHandler(TestItemEventArgs args);
-    public delegate void TestFilesLoadingEventHandler(TestFilesLoadingEventArgs args);
-
-    public interface ITestModel : IServiceLocator, System.IDisposable
+    public interface ITestModel : ITestEvents, IServiceLocator, System.IDisposable
     {
-        #region Events
-
-        // Events related to loading and unloading tests.
-        event TestFilesLoadingEventHandler TestsLoading;
-        event TestNodeEventHandler TestLoaded;
-        event TestNodeEventHandler TestReloaded;
-        event TestEventHandler TestUnloaded;
-
-        // Events related to running tests
-        event RunStartingEventHandler RunStarting;
-        event TestNodeEventHandler SuiteStarting;
-        event TestNodeEventHandler TestStarting;
-
-        event TestResultEventHandler RunFinished;
-        event TestResultEventHandler SuiteFinished;
-        event TestResultEventHandler TestFinished;
-
-        // Event used to broadcast a change in the selected
-        // item, so that all presenters may be notified.
-        event TestItemEventHandler SelectedItemChanged;
-
-        #endregion
-
         #region Properties
 
         CommandLineOptions Options { get; }

--- a/src/nunit.testmodel/Model/TestEventArgs.cs
+++ b/src/nunit.testmodel/Model/TestEventArgs.cs
@@ -87,6 +87,20 @@ namespace TestCentric.Gui.Model
         public ITestItem TestItem { get; private set; }
     }
 
+    public class TestOutputEventArgs : EventArgs
+    {
+        public TestOutputEventArgs(string testName, string stream, string text)
+        {
+            TestName = testName;
+            Stream = stream;
+            Text = text;
+        }
+
+        public string TestName { get; }
+        public string Stream { get; }
+        public string Text { get; }
+    }
+
     public class TestFilesLoadingEventArgs : EventArgs
     {
         public TestFilesLoadingEventArgs(IList<string> testFilesLoading)

--- a/src/nunit.testmodel/Model/TestEventDispatcher.cs
+++ b/src/nunit.testmodel/Model/TestEventDispatcher.cs
@@ -1,0 +1,156 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Xml;
+using NUnit.Engine;
+
+namespace TestCentric.Gui.Model
+{
+    public class TestEventDispatcher : ITestEvents, ITestEventListener
+    {
+        private TestModel _model;
+
+        public TestEventDispatcher(TestModel model)
+        {
+            _model = model;
+        }
+
+        #region Public Methods to Fire Events
+
+        public void FireTestsLoading(IList<string> files)
+        {
+            TestsLoading?.Invoke(new TestFilesLoadingEventArgs(files));
+        }
+
+        //public void FireTestsReloading()
+        //{
+        //    TestsReloading?.Invoke(new TestEventArgs());
+        //}
+
+        //public void FireTestsUnloading()
+        //{
+        //    TestsUnloading?.Invoke(new TestEventArgs());
+        //}
+
+        public void FireTestLoaded(TestNode testNode)
+        {
+            TestLoaded?.Invoke(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
+        }
+
+        public void FireTestUnloaded()
+        {
+            TestUnloaded?.Invoke(new TestEventArgs(TestAction.TestUnloaded));
+        }
+
+        public void FireTestReloaded(TestNode testNode)
+        {
+            TestReloaded?.Invoke(new TestNodeEventArgs(TestAction.TestReloaded, testNode));
+        }
+
+        public void FireSelectedItemChanged(ITestItem testItem)
+        {
+            SelectedItemChanged?.Invoke(new TestItemEventArgs(testItem));
+        }
+
+        //public void FireCategorySelectionChanged()
+        //{
+        //    CategorySelectionChanged?.Invoke(new TestEventArgs());
+        //}
+
+        #endregion
+
+        #region ITestEvents Implementation
+
+        // Test loading events
+        public event TestFilesLoadingEventHandler TestsLoading;
+        public event TestEventHandler TestsReloading;
+        public event TestEventHandler TestsUnloading;
+
+        public event TestNodeEventHandler TestLoaded;
+        public event TestNodeEventHandler TestReloaded;
+        public event TestEventHandler TestUnloaded;
+
+        // Test running events
+        public event RunStartingEventHandler RunStarting;
+        public event TestResultEventHandler RunFinished;
+
+        public event TestNodeEventHandler SuiteStarting;
+        public event TestResultEventHandler SuiteFinished;
+
+        public event TestNodeEventHandler TestStarting;
+        public event TestResultEventHandler TestFinished;
+
+        public event TestOutputEventHandler TestOutput;
+
+        // Test Selection Event
+        public event TestItemEventHandler SelectedItemChanged;
+
+        public event TestEventHandler CategorySelectionChanged;
+
+        #endregion
+
+        #region ITestEventListener Implementation
+
+        public void OnTestEvent(string report)
+        {
+            XmlNode xmlNode = XmlHelper.CreateXmlNode(report);
+
+            switch (xmlNode.Name)
+            {
+                case "start-test":
+                    TestStarting?.Invoke(new TestNodeEventArgs(TestAction.TestStarting, new TestNode(xmlNode)));
+                    break;
+
+                case "start-suite":
+                    SuiteStarting?.Invoke(new TestNodeEventArgs(TestAction.SuiteStarting, new TestNode(xmlNode)));
+                    break;
+
+                case "start-run":
+                    RunStarting?.Invoke(new RunStartingEventArgs(xmlNode.GetAttribute("count", -1)));
+                    break;
+
+                case "test-case":
+                    ResultNode result = new ResultNode(xmlNode);
+                    _model.Results[result.Id] = result;
+                    TestFinished?.Invoke(new TestResultEventArgs(TestAction.TestFinished, result));
+                    break;
+
+                case "test-suite":
+                    result = new ResultNode(xmlNode);
+                    _model.Results[result.Id] = result;
+                    SuiteFinished?.Invoke(new TestResultEventArgs(TestAction.SuiteFinished, result));
+                    break;
+
+                case "test-run":
+                    result = new ResultNode(xmlNode);
+                    _model.Results[result.Id] = result;
+                    RunFinished?.Invoke(new TestResultEventArgs(TestAction.RunFinished, result));
+                    break;
+            }
+        }
+        
+        #endregion
+    }
+}

--- a/src/nunit.testmodel/Model/TestModel.cs
+++ b/src/nunit.testmodel/Model/TestModel.cs
@@ -51,6 +51,9 @@ namespace TestCentric.Gui.Model
 
         // Test loading events
         public event TestFilesLoadingEventHandler TestsLoading;
+        public event TestEventHandler TestsReloading;
+        public event TestEventHandler TestsUnloading;
+
         public event TestNodeEventHandler TestLoaded;
         public event TestNodeEventHandler TestReloaded;
         public event TestEventHandler TestUnloaded;
@@ -65,8 +68,12 @@ namespace TestCentric.Gui.Model
         public event TestNodeEventHandler TestStarting;
         public event TestResultEventHandler TestFinished;
 
+        public event TestOutputEventHandler TestOutput;
+
         // Test Selection Event
         public event TestItemEventHandler SelectedItemChanged;
+
+        public event TestEventHandler CategorySelectionChanged;
 
         #endregion
 

--- a/src/nunit.testmodel/nunit.testmodel.csproj
+++ b/src/nunit.testmodel/nunit.testmodel.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Model\RunState.cs" />
     <Compile Include="Model\TestAction.cs" />
     <Compile Include="Model\TestEventArgs.cs" />
+    <Compile Include="Model\TestEventDispatcher.cs" />
     <Compile Include="Model\TestModel.cs" />
     <Compile Include="Model\TestNode.cs" />
     <Compile Include="Model\TestSelection.cs" />

--- a/src/nunit.testmodel/nunit.testmodel.csproj
+++ b/src/nunit.testmodel/nunit.testmodel.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{E978A8D7-E4A4-4DE9-94DF-D82BD764936B}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Nunit.Gui</RootNamespace>
+    <RootNamespace>TestCentric.Gui</RootNamespace>
     <AssemblyName>nunit.testmodel</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -45,6 +45,7 @@
     <Compile Include="CommandLineOptions.cs" />
     <Compile Include="EnginePackageSettings.cs" />
     <Compile Include="ExtensionAttribute.cs" />
+    <Compile Include="Model\ITestEvents.cs" />
     <Compile Include="Model\ITestItem.cs" />
     <Compile Include="Model\ITestModel.cs" />
     <Compile Include="Model\ResultNode.cs" />

--- a/src/tests/Presenters/Main/WhenTestRunBegins.cs
+++ b/src/tests/Presenters/Main/WhenTestRunBegins.cs
@@ -35,7 +35,7 @@ namespace TestCentric.Gui.Presenters.Main
         {
             Model.HasTests.Returns(true);
             Model.IsTestRunning.Returns(true);
-            Model.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
+            Model.Events.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
         }
 
 #if NYI

--- a/src/tests/Presenters/Main/WhenTestRunCompletes.cs
+++ b/src/tests/Presenters/Main/WhenTestRunCompletes.cs
@@ -38,7 +38,7 @@ namespace TestCentric.Gui.Presenters.Main
             Model.IsTestRunning.Returns(false);
 
             var resultNode = new ResultNode("<test-suite/>");
-            Model.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.RunFinished, resultNode));
+            Model.Events.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.RunFinished, resultNode));
         }
 
 #if NYI

--- a/src/tests/Presenters/Main/WhenTestsAreLoaded.cs
+++ b/src/tests/Presenters/Main/WhenTestsAreLoaded.cs
@@ -42,7 +42,7 @@ namespace TestCentric.Gui.Presenters.Main
             doc.LoadXml("<test-suite id='1'/>");
             TestNode testNode = new TestNode(doc.FirstChild);
             Model.Tests.Returns(testNode);
-            Model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
+            Model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
         }
 
 #if NYI

--- a/src/tests/Presenters/Main/WhenTestsAreLoading.cs
+++ b/src/tests/Presenters/Main/WhenTestsAreLoading.cs
@@ -37,7 +37,7 @@ namespace TestCentric.Gui.Presenters.Main
                 {
                     "C:\\git\\projects\\pull-request\\SomeAssembly.AcceptanceTests.dll"
                 });
-            Model.TestsLoading += Raise.Event<TestFilesLoadingEventHandler>(arguments);
+            Model.Events.TestsLoading += Raise.Event<TestFilesLoadingEventHandler>(arguments);
 
             View.Received().OnTestAssembliesLoading("Loading Assembly: SomeAssembly.AcceptanceTests.dll");
         }
@@ -51,7 +51,7 @@ namespace TestCentric.Gui.Presenters.Main
                     "C:\\git\\projects\\pull-request\\SomeAssembly.IntegrationTests.dll",
                     "C:\\git\\projects\\pull-request\\SomeAssembly.AcceptanceTests.dll"
                 });
-            Model.TestsLoading += Raise.Event<TestFilesLoadingEventHandler>(arguments);
+            Model.Events.TestsLoading += Raise.Event<TestFilesLoadingEventHandler>(arguments);
 
             View.Received().OnTestAssembliesLoading("Loading 3 Assemblies...");
         }

--- a/src/tests/Presenters/Main/WhenTestsAreReloaded.cs
+++ b/src/tests/Presenters/Main/WhenTestsAreReloaded.cs
@@ -42,7 +42,7 @@ namespace TestCentric.Gui.Presenters.Main
             doc.LoadXml("<test-suite id='1'/>");
             TestNode testNode = new TestNode(doc.FirstChild);
             Model.Tests.Returns(testNode);
-            Model.TestReloaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, testNode));
+            Model.Events.TestReloaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, testNode));
         }
 
 #if NYI

--- a/src/tests/Presenters/Main/WhenTestsAreUnloaded.cs
+++ b/src/tests/Presenters/Main/WhenTestsAreUnloaded.cs
@@ -35,7 +35,7 @@ namespace TestCentric.Gui.Presenters.Main
         {
             Model.HasTests.Returns(false);
             Model.IsTestRunning.Returns(false);
-            Model.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestUnloaded));
+            Model.Events.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestUnloaded));
         }
 
 #if NYI

--- a/src/tests/Presenters/ProgressBarPresenterTests.cs
+++ b/src/tests/Presenters/ProgressBarPresenterTests.cs
@@ -59,7 +59,7 @@ namespace TestCentric.Gui.Presenters
             _model.IsTestRunning.Returns(false);
 
             var testNode = new TestNode("<test-suite id='1' testcasecount='1234'/>");
-            _model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
+            _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
 
             _view.Received().Initialize(100);
         }
@@ -69,7 +69,7 @@ namespace TestCentric.Gui.Presenters
         {
             _model.HasTests.Returns(false);
             _model.IsTestRunning.Returns(false);
-            _model.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestUnloaded));
+            _model.Events.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestUnloaded));
 
             _view.Received().Initialize(100);
         }
@@ -81,7 +81,7 @@ namespace TestCentric.Gui.Presenters
             _model.IsTestRunning.Returns(false);
 
             var testNode = new TestNode("<test-suite id='1' testcasecount='1234'/>");
-            _model.TestReloaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, testNode));
+            _model.Events.TestReloaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, testNode));
 
             _view.Received().Initialize(100);
         }
@@ -91,7 +91,7 @@ namespace TestCentric.Gui.Presenters
         {
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(true);
-            _model.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
+            _model.Events.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
 
             _view.Received().Initialize(1234);
         }
@@ -101,7 +101,7 @@ namespace TestCentric.Gui.Presenters
         {
             var result = new ResultNode("<test-case id='1'/>");
 
-            _model.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, result));
+            _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, result));
 
             _view.Received().Progress++;
         }
@@ -111,7 +111,7 @@ namespace TestCentric.Gui.Presenters
         {
             var result = new ResultNode("<test-suite id='1'/>");
 
-            _model.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.SuiteFinished, result));
+            _model.Events.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.SuiteFinished, result));
 
             _view.DidNotReceive().Progress++;
         }
@@ -165,8 +165,8 @@ namespace TestCentric.Gui.Presenters
 
             _model.HasTests.Returns(true);
             _model.Tests.Returns(result);
-            _model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, result));
-            _model.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, result));
+            _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, result));
+            _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, result));
 
             Assert.That(_view.Status, Is.EqualTo(expectedStatus));
         }

--- a/src/tests/Presenters/StatusBarPresenterTests.cs
+++ b/src/tests/Presenters/StatusBarPresenterTests.cs
@@ -70,7 +70,7 @@ namespace TestCentric.Gui.Presenters
         {
             _model.HasTests.Returns(false);
             _model.IsTestRunning.Returns(false);
-            _model.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestUnloaded));
+            _model.Events.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestUnloaded));
 
             _view.Received().OnTestUnloaded();
         }
@@ -80,7 +80,7 @@ namespace TestCentric.Gui.Presenters
         {
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(true);
-            _model.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
+            _model.Events.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
 
             _view.Received().OnRunStarting(1234);
         }
@@ -90,7 +90,7 @@ namespace TestCentric.Gui.Presenters
         {
             var result = new ResultNode(XmlHelper.CreateXmlNode("<test-case id='1'/>"));
 
-            _model.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, result));
+            _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, result));
 
             _view.Received().OnTestPassed();
         }
@@ -100,7 +100,7 @@ namespace TestCentric.Gui.Presenters
         {
             var result = new ResultNode(XmlHelper.CreateXmlNode("<test-run/>"));
 
-            _model.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.RunFinished, result));
+            _model.Events.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.RunFinished, result));
 
             _view.Received().OnRunFinished(0);
             _view.Received().OnTestRunSummaryCompiled(Arg.Any<string>());

--- a/src/tests/Presenters/TestTree/WhenTestRunBegins.cs
+++ b/src/tests/Presenters/TestTree/WhenTestRunBegins.cs
@@ -36,7 +36,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.IsPackageLoaded.Returns(true);
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(true);
-            _model.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
+            _model.Events.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
         }
 
         [Test]

--- a/src/tests/Presenters/TestTree/WhenTestRunCompletes.cs
+++ b/src/tests/Presenters/TestTree/WhenTestRunCompletes.cs
@@ -40,7 +40,7 @@ namespace TestCentric.Gui.Presenters.TestTree
 
             var resultNode = new ResultNode("<test-suite/>");
 
-            _model.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.RunFinished, resultNode));
+            _model.Events.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.RunFinished, resultNode));
         }
 
 

--- a/src/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
+++ b/src/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
@@ -38,7 +38,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(false);
 
-            _model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, new TestNode("<test-run/>")));
+            _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, new TestNode("<test-run/>")));
         }
 
         [Test]

--- a/src/tests/Presenters/TestTree/WhenTestsAreReloaded.cs
+++ b/src/tests/Presenters/TestTree/WhenTestsAreReloaded.cs
@@ -38,7 +38,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(false);
 
-            _model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, new TestNode("<test-run/>")));
+            _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, new TestNode("<test-run/>")));
         }
 
         [Test]

--- a/src/tests/Presenters/TestTree/WhenTestsAreUnloaded.cs
+++ b/src/tests/Presenters/TestTree/WhenTestsAreUnloaded.cs
@@ -36,7 +36,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.IsPackageLoaded.Returns(true);
             _model.HasTests.Returns(false);
             _model.IsTestRunning.Returns(false);
-            _model.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestUnloaded));
+            _model.Events.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestUnloaded));
         }
 
         [Test]

--- a/src/tests/Presenters/TreeViewPresenterTests.cs
+++ b/src/tests/Presenters/TreeViewPresenterTests.cs
@@ -95,8 +95,8 @@ namespace TestCentric.Gui.Presenters
 
             //var treeNode = _adapter.MakeTreeNode(result);
             //_adapter.NodeIndex[suiteResult.Id] = treeNode;
-            _model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
-            _model.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, resultNode));
+            _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
+            _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, resultNode));
 
             _view.Tree.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex);
         }

--- a/src/tests/nunit-gui.tests.csproj
+++ b/src/tests/nunit-gui.tests.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{49D8D9F5-FD8D-4B4F-800C-68DCEE9AE166}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NUnit.Gui</RootNamespace>
+    <RootNamespace>TestCentric.Gui</RootNamespace>
     <AssemblyName>nunit-gui.tests</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
This makes the ITestEvent interface match that of the TestCentric GUI and uses a separate dispatcher to implement the interface. This change is part of issue #249.